### PR TITLE
stop tracks when stopping the recording

### DIFF
--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -56,6 +56,7 @@ export class VoiceRecorderImpl {
     }
     try {
       this.mediaRecorder.stop();
+      this.mediaRecorder.stream.getTracks().forEach((t)=>t.stop());
       return this.pendingResult;
     } catch (ignore) {
       throw failedToFetchRecordingError();


### PR DESCRIPTION
This will make the red dot in Chrome (and possibly other browsers) disappear after the recording has been stopped.