### PR TITLE
fix: add safari support

### DIFF
--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -66,6 +66,16 @@ export class VoiceRecorderImpl {
     }
 
     public static async hasAudioRecordingPermission(): Promise<GenericResponse> {
+        // Safari does not support navigator.permissions.query
+        if (!navigator.permissions.query) {
+            if (navigator.mediaDevices !== undefined) {
+                return navigator.mediaDevices.getUserMedia({audio: true})
+                    .then(() => successResponse())
+                    .catch(() => {
+                        throw couldNotQueryPermissionStatusError()
+                    });
+            }
+        }
         return navigator.permissions.query({name: 'microphone' as any})
             .then(result => ({value: result.state === 'granted'}))
             .catch(() => {


### PR DESCRIPTION
We are using this repo for our app, and the recording is not supported in safari browsers. This code accesses the mediaDevices on the navigator, because navigator.permission.query is not supported in safari, so you cannot record in safari currently. 
This small code section fixes this

![image](https://github.com/tchvu3/capacitor-voice-recorder/assets/54836876/d9071f1b-87db-4507-892d-7aa1cc95963b)
