### PR TITLE
Added "RecordingStatus" enum

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -12,8 +12,14 @@ export interface GenericResponse {
   value: boolean;
 }
 
+export enum RecordingStatus {
+  RECORDING = 'RECORDING',
+  PAUSED = 'PAUSED',
+  NONE = 'NONE'
+}
+
 export interface CurrentRecordingStatus {
-  status: 'RECORDING' | 'PAUSED' | 'NONE';
+  status: RecordingStatus | 'RECORDING' | 'PAUSED' | 'NONE';
 }
 
 export interface VoiceRecorderPlugin {


### PR DESCRIPTION
Modified definitions.ts interface CurrentRecordingStatus. Property "status" is now of type enum RecordingStatus, which are the same string values as before, "NONE", "RECORDING", and "PAUSED".