### PR TITLE
feat(performance): add option to save file to filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ npx cap sync
 
 ## Configuration
 
+### Using with Android
+
+Add the following to your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+```
+
 ### Using with iOS
 
 Add the following to your `Info.plist`:

--- a/README.md
+++ b/README.md
@@ -108,11 +108,19 @@ VoiceRecorder.hasAudioRecordingPermission().then((result: GenericResponse) => co
 
 Start the audio recording.
 
+Optional options can be used with this method to save the file in the device's filesystem and return a uri to that file instead of a base64 string.
+This greatly increases performance for large files.
+
 ```typescript
-VoiceRecorder.startRecording()
+VoiceRecorder.startRecording(options?: RecordingOptions)
     .then((result: GenericResponse) => console.log(result.value))
     .catch(error => console.log(error));
 ```
+
+| Option            | Description                                                                                          |
+|-------------------|------------------------------------------------------------------------------------------------------|
+| directory         | Specifies a Capacitor Filesystem [Directory](https://capacitorjs.com/docs/apis/filesystem#directory) |
+| subDirectory      | Specifies a custom sub-directory (optional)                                                          |
 
 | Return Value      | Description                     |
 |-------------------|---------------------------------|
@@ -130,6 +138,8 @@ VoiceRecorder.startRecording()
 
 Stops the audio recording and returns the recording data.
 
+When a `directory` option has been passed to the `VoiceRecorder.startRecording` method the data will include a `uri` instead of a `recordDataBase64`
+
 ```typescript
 VoiceRecorder.stopRecording()
     .then((result: RecordingData) => console.log(result.value))
@@ -141,6 +151,7 @@ VoiceRecorder.stopRecording()
 | `recordDataBase64` | The recorded audio data in Base64 format.      |
 | `msDuration`       | The duration of the recording in milliseconds. |
 | `mimeType`         | The MIME type of the recorded audio.           |
+| `uri`              | The URI to the audio file                      |
 
 | Error Code                  | Description                                          |
 |-----------------------------|------------------------------------------------------|

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/CustomMediaRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/CustomMediaRecorder.java
@@ -3,18 +3,23 @@ package com.tchvu3.capacitorvoicerecorder;
 import android.content.Context;
 import android.media.MediaRecorder;
 import android.os.Build;
+import android.os.Environment;
 import java.io.File;
 import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class CustomMediaRecorder {
 
     private final Context context;
+    private final RecordOptions options;
     private MediaRecorder mediaRecorder;
     private File outputFile;
     private CurrentRecordingStatus currentRecordingStatus = CurrentRecordingStatus.NONE;
 
-    public CustomMediaRecorder(Context context) throws IOException {
+    public CustomMediaRecorder(Context context, RecordOptions options) throws IOException {
         this.context = context;
+        this.options = options;
         generateMediaRecorder();
     }
 
@@ -31,9 +36,41 @@ public class CustomMediaRecorder {
 
     private void setRecorderOutputFile() throws IOException {
         File outputDir = context.getCacheDir();
-        outputFile = File.createTempFile("voice_record_temp", ".aac", outputDir);
-        outputFile.deleteOnExit();
+        String directory = options.directory();
+        String subDirectory = options.subDirectory();
+
+        if (directory != null) {
+            outputDir = this.getDirectory(directory);
+            if (subDirectory != null) {
+                Pattern pattern = Pattern.compile("^/?(.+[^/])/?$");
+                Matcher matcher = pattern.matcher(subDirectory);
+                if (matcher.matches()) {
+                    outputDir = new File(outputDir, matcher.group(1));
+                    if (!outputDir.exists()) {
+                        outputDir.mkdirs();
+                    }
+                }
+            }
+        }
+
+        outputFile = File.createTempFile(String.format("recording-%d", System.currentTimeMillis()), ".aac", outputDir);
+
+        if (directory == null) {
+            outputFile.deleteOnExit();
+        }
+
         mediaRecorder.setOutputFile(outputFile.getAbsolutePath());
+    }
+
+    private File getDirectory(String directory) {
+        return switch (directory) {
+            case "DOCUMENTS" -> Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
+            case "DATA", "LIBRARY" -> context.getFilesDir();
+            case "CACHE" -> context.getCacheDir();
+            case "EXTERNAL" -> context.getExternalFilesDir(null);
+            case "EXTERNAL_STORAGE" -> Environment.getExternalStorageDirectory();
+            default -> null;
+        };
     }
 
     public void startRecording() {
@@ -49,6 +86,10 @@ public class CustomMediaRecorder {
 
     public File getOutputFile() {
         return outputFile;
+    }
+
+    public RecordOptions getRecordOptions() {
+        return options;
     }
 
     public boolean pauseRecording() throws NotSupportedOsVersion {
@@ -94,7 +135,7 @@ public class CustomMediaRecorder {
     private static boolean canPhoneCreateMediaRecorderWhileHavingPermission(Context context) {
         CustomMediaRecorder tempMediaRecorder = null;
         try {
-            tempMediaRecorder = new CustomMediaRecorder(context);
+            tempMediaRecorder = new CustomMediaRecorder(context, new RecordOptions(null, null));
             tempMediaRecorder.startRecording();
             tempMediaRecorder.stopRecording();
             return true;

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordData.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordData.java
@@ -4,16 +4,18 @@ import com.getcapacitor.JSObject;
 
 public class RecordData {
 
+    private String uri;
     private String recordDataBase64;
     private String mimeType;
     private int msDuration;
 
     public RecordData() {}
 
-    public RecordData(String recordDataBase64, int msDuration, String mimeType) {
+    public RecordData(String recordDataBase64, int msDuration, String mimeType, String uri) {
         this.recordDataBase64 = recordDataBase64;
         this.msDuration = msDuration;
         this.mimeType = mimeType;
+        this.uri = uri;
     }
 
     public String getRecordDataBase64() {
@@ -45,6 +47,7 @@ public class RecordData {
         toReturn.put("recordDataBase64", recordDataBase64);
         toReturn.put("msDuration", msDuration);
         toReturn.put("mimeType", mimeType);
+        toReturn.put("uri", uri);
         return toReturn;
     }
 }

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordOptions.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordOptions.java
@@ -1,0 +1,3 @@
+package com.tchvu3.capacitorvoicerecorder;
+
+public record RecordOptions(String directory, String subDirectory) {}

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.net.Uri;
 import android.util.Base64;
 import com.getcapacitor.PermissionState;
 import com.getcapacitor.Plugin;
@@ -77,7 +78,10 @@ public class VoiceRecorder extends Plugin {
         }
 
         try {
-            mediaRecorder = new CustomMediaRecorder(getContext());
+            String directory = call.getString("directory");
+            String subDirectory = call.getString("subDirectory");
+            RecordOptions options = new RecordOptions(directory, subDirectory);
+            mediaRecorder = new CustomMediaRecorder(getContext(), options);
             mediaRecorder.startRecording();
             call.resolve(ResponseGenerator.successResponse());
         } catch (Exception exp) {
@@ -96,12 +100,23 @@ public class VoiceRecorder extends Plugin {
         try {
             mediaRecorder.stopRecording();
             File recordedFile = mediaRecorder.getOutputFile();
+            RecordOptions options = mediaRecorder.getRecordOptions();
+
+            String recordDataBase64 = null;
+            String uri = null;
+            if (options.directory() != null) {
+                uri = Uri.fromFile(recordedFile).toString();
+            } else {
+                recordDataBase64 = readRecordedFileAsBase64(recordedFile);
+            }
+
             RecordData recordData = new RecordData(
-                readRecordedFileAsBase64(recordedFile),
+                recordDataBase64,
                 getMsDurationOfAudioFile(recordedFile.getAbsolutePath()),
-                "audio/aac"
+                "audio/aac",
+                uri
             );
-            if (recordData.getRecordDataBase64() == null || recordData.getMsDuration() < 0) {
+            if ((recordDataBase64 == null && uri == null) || recordData.getMsDuration() < 0) {
                 call.reject(Messages.EMPTY_RECORDING);
             } else {
                 call.resolve(ResponseGenerator.dataResponse(recordData.toJSObject()));
@@ -109,7 +124,11 @@ public class VoiceRecorder extends Plugin {
         } catch (Exception exp) {
             call.reject(Messages.FAILED_TO_FETCH_RECORDING, exp);
         } finally {
-            mediaRecorder.deleteOutputFile();
+            RecordOptions options = mediaRecorder.getRecordOptions();
+            if (options.directory() == null) {
+                mediaRecorder.deleteOutputFile();
+            }
+
             mediaRecorder = null;
         }
     }

--- a/ios/Plugin/CurrentRecordingStatus.swift
+++ b/ios/Plugin/CurrentRecordingStatus.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum CurrentRecordingStatus: String {
-    
+
     case RECORDING
     case PAUSED
     case NONE
-    
+
 }

--- a/ios/Plugin/CustomMediaRecorder.swift
+++ b/ios/Plugin/CustomMediaRecorder.swift
@@ -3,11 +3,22 @@ import AVFoundation
 
 class CustomMediaRecorder {
 
+    public struct RecordOptions {
+        let directory: String?
+        let subDirectory: String?
+
+        public init(directory: String? = nil, subDirectory: String? = nil) {
+            self.directory = directory
+            self.subDirectory = subDirectory
+        }
+    }
+
     private var recordingSession: AVAudioSession!
     private var audioRecorder: AVAudioRecorder!
     private var audioFilePath: URL!
     private var originalRecordingSessionCategory: AVAudioSession.Category!
     private var status = CurrentRecordingStatus.NONE
+    private var wasRecordedWithOptions: Bool = false
 
     private let settings = [
         AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
@@ -16,17 +27,40 @@ class CustomMediaRecorder {
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
     ]
 
-    private func getDirectoryToSaveAudioFile() -> URL {
-        return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    private func getDirectoryToSaveAudioFile(options: RecordOptions? = nil) -> URL {
+        if let options = options,
+           let directoryString = options.directory,
+           let searchPath = getDirectory(directory: directoryString) {
+            let baseURL = FileManager.default.urls(for: searchPath, in: .userDomainMask).first!
+
+            if let subDirectory = options.subDirectory {
+                let fullPath = baseURL.appendingPathComponent(subDirectory)
+
+                // Create subdirectory if it doesn't exist
+                do {
+                    if !FileManager.default.fileExists(atPath: fullPath.path) {
+                        try FileManager.default.createDirectory(at: fullPath, withIntermediateDirectories: true)
+                    }
+                    return fullPath
+                } catch {
+                    print("Error creating directory: \(error)")
+                }
+            }
+
+            return baseURL
+        }
+
+        return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true).appendingPathComponent("\(UUID().uuidString).aac")
     }
 
-    func startRecording() -> Bool {
+    func startRecording(options: RecordOptions? = nil) -> Bool {
+        wasRecordedWithOptions = options != nil
         do {
             recordingSession = AVAudioSession.sharedInstance()
             originalRecordingSessionCategory = recordingSession.category
             try recordingSession.setCategory(AVAudioSession.Category.playAndRecord)
             try recordingSession.setActive(true)
-            audioFilePath = getDirectoryToSaveAudioFile().appendingPathComponent("\(UUID().uuidString).aac")
+            audioFilePath = getDirectoryToSaveAudioFile(options: options)
             audioRecorder = try AVAudioRecorder(url: audioFilePath, settings: settings)
             audioRecorder.record()
             status = CurrentRecordingStatus.RECORDING
@@ -50,6 +84,24 @@ class CustomMediaRecorder {
 
     func getOutputFile() -> URL {
         return audioFilePath
+    }
+
+    func wasRecordedToFile() -> Bool {
+        return wasRecordedWithOptions
+    }
+
+    func getDirectory(directory: String?) -> FileManager.SearchPathDirectory? {
+        if let directory = directory {
+            switch directory {
+            case "CACHE":
+                return .cachesDirectory
+            case "DATA", "LIBRARY":
+                return .libraryDirectory
+            default:
+                return .documentDirectory
+            }
+        }
+        return nil
     }
 
     func pauseRecording() -> Bool {

--- a/ios/Plugin/CustomMediaRecorder.swift
+++ b/ios/Plugin/CustomMediaRecorder.swift
@@ -2,25 +2,25 @@ import Foundation
 import AVFoundation
 
 class CustomMediaRecorder {
-    
+
     private var recordingSession: AVAudioSession!
     private var audioRecorder: AVAudioRecorder!
     private var audioFilePath: URL!
     private var originalRecordingSessionCategory: AVAudioSession.Category!
     private var status = CurrentRecordingStatus.NONE
-    
+
     private let settings = [
         AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
         AVSampleRateKey: 44100,
         AVNumberOfChannelsKey: 1,
         AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
     ]
-    
+
     private func getDirectoryToSaveAudioFile() -> URL {
         return URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
     }
-    
-    public func startRecording() -> Bool {
+
+    func startRecording() -> Bool {
         do {
             recordingSession = AVAudioSession.sharedInstance()
             originalRecordingSessionCategory = recordingSession.category
@@ -35,8 +35,8 @@ class CustomMediaRecorder {
             return false
         }
     }
-    
-    public func stopRecording() {
+
+    func stopRecording() {
         do {
             audioRecorder.stop()
             try recordingSession.setActive(false)
@@ -47,13 +47,13 @@ class CustomMediaRecorder {
             status = CurrentRecordingStatus.NONE
         } catch {}
     }
-    
-    public func getOutputFile() -> URL {
+
+    func getOutputFile() -> URL {
         return audioFilePath
     }
-    
-    public func pauseRecording() -> Bool {
-        if(status == CurrentRecordingStatus.RECORDING) {
+
+    func pauseRecording() -> Bool {
+        if status == CurrentRecordingStatus.RECORDING {
             audioRecorder.pause()
             status = CurrentRecordingStatus.PAUSED
             return true
@@ -61,9 +61,9 @@ class CustomMediaRecorder {
             return false
         }
     }
-    
-    public func resumeRecording() -> Bool {
-        if(status == CurrentRecordingStatus.PAUSED) {
+
+    func resumeRecording() -> Bool {
+        if status == CurrentRecordingStatus.PAUSED {
             audioRecorder.record()
             status = CurrentRecordingStatus.RECORDING
             return true
@@ -71,9 +71,9 @@ class CustomMediaRecorder {
             return false
         }
     }
-    
-    public func getCurrentStatus() -> CurrentRecordingStatus {
+
+    func getCurrentStatus() -> CurrentRecordingStatus {
         return status
     }
-    
+
 }

--- a/ios/Plugin/Messages.swift
+++ b/ios/Plugin/Messages.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-
 struct Messages {
-    
+
     static let MISSING_PERMISSION = "MISSING_PERMISSION"
     static let CANNOT_RECORD_ON_THIS_PHONE = "CANNOT_RECORD_ON_THIS_PHONE"
     static let FAILED_TO_RECORD = "FAILED_TO_RECORD"
@@ -11,5 +10,5 @@ struct Messages {
     static let EMPTY_RECORDING = "EMPTY_RECORDING"
     static let ALREADY_RECORDING = "ALREADY_RECORDING"
     static let MICROPHONE_BEING_USED = "MICROPHONE_BEING_USED"
-    
+
 }

--- a/ios/Plugin/RecordData.swift
+++ b/ios/Plugin/RecordData.swift
@@ -1,17 +1,20 @@
 import Foundation
 
-struct RecordData {
+public struct RecordData {
+    public let recordDataBase64: String?
+    public let uri: String?
+    public let mimeType: String
+    public let msDuration: Int
 
-    let recordDataBase64: String?
-    let mimeType: String
-    let msDuration: Int
-
-    func toDictionary() -> [String: Any] {
-        return [
-            "recordDataBase64": recordDataBase64 ?? "",
+    public func toDictionary() -> [String: Any] {
+        var dict: [String: Any] = [
+            "mimeType": mimeType,
             "msDuration": msDuration,
-            "mimeType": mimeType
+            "recordDataBase64": recordDataBase64 ?? ""
         ]
+        if let uri = uri {
+            dict["uri"] = uri
+        }
+        return dict
     }
-
 }

--- a/ios/Plugin/RecordData.swift
+++ b/ios/Plugin/RecordData.swift
@@ -1,20 +1,19 @@
 import Foundation
 
-public struct RecordData {
+struct RecordData {
+
     public let recordDataBase64: String?
-    public let uri: String?
     public let mimeType: String
     public let msDuration: Int
+    public let uri: String?
 
-    public func toDictionary() -> [String: Any] {
-        var dict: [String: Any] = [
-            "mimeType": mimeType,
+    public func toDictionary() -> Dictionary<String, Any> {
+        return [
+            "recordDataBase64": recordDataBase64 ?? "",
             "msDuration": msDuration,
-            "recordDataBase64": recordDataBase64 ?? ""
+            "mimeType": mimeType,
+            "uri": uri ?? ""
         ]
-        if let uri = uri {
-            dict["uri"] = uri
-        }
-        return dict
     }
+
 }

--- a/ios/Plugin/RecordData.swift
+++ b/ios/Plugin/RecordData.swift
@@ -1,17 +1,17 @@
 import Foundation
 
 struct RecordData {
-    
-    public let recordDataBase64: String?
-    public let mimeType: String
-    public let msDuration: Int
-    
-    public func toDictionary() -> Dictionary<String, Any> {
+
+    let recordDataBase64: String?
+    let mimeType: String
+    let msDuration: Int
+
+    func toDictionary() -> [String: Any] {
         return [
             "recordDataBase64": recordDataBase64 ?? "",
             "msDuration": msDuration,
             "mimeType": mimeType
         ]
     }
-    
+
 }

--- a/ios/Plugin/RecordOptions.swift
+++ b/ios/Plugin/RecordOptions.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct RecordOptions {
+
+    public let directory: String?
+    public let subDirectory: String?
+
+}

--- a/ios/Plugin/ResponseGenerator.swift
+++ b/ios/Plugin/ResponseGenerator.swift
@@ -1,28 +1,28 @@
 import Foundation
 
 struct ResponseGenerator {
-    
+
     private static let VALUE_RESPONSE_KEY = "value"
     private static let STATUS_RESPONSE_KEY = "status"
-    
-    public static func fromBoolean(_ value: Bool) -> Dictionary<String, Bool> {
+
+    static func fromBoolean(_ value: Bool) -> [String: Bool] {
         return value ? successResponse() : failResponse()
     }
-    
-    public static func successResponse() -> Dictionary<String, Bool> {
+
+    static func successResponse() -> [String: Bool] {
         return [VALUE_RESPONSE_KEY: true]
     }
-    
-    public static func failResponse() -> Dictionary<String, Bool> {
+
+    static func failResponse() -> [String: Bool] {
         return [VALUE_RESPONSE_KEY: false]
     }
-    
-    public static func dataResponse(_ data: Any) -> Dictionary<String, Any> {
+
+    static func dataResponse(_ data: Any) -> [String: Any] {
         return [VALUE_RESPONSE_KEY: data]
     }
-    
-    public static func statusResponse(_ data: CurrentRecordingStatus) -> Dictionary<String, String> {
+
+    static func statusResponse(_ data: CurrentRecordingStatus) -> [String: String] {
         return [STATUS_RESPONSE_KEY: data.rawValue]
     }
-    
+
 }

--- a/ios/Plugin/ResponseGenerator.swift
+++ b/ios/Plugin/ResponseGenerator.swift
@@ -5,23 +5,23 @@ struct ResponseGenerator {
     private static let VALUE_RESPONSE_KEY = "value"
     private static let STATUS_RESPONSE_KEY = "status"
 
-    static func fromBoolean(_ value: Bool) -> [String: Bool] {
+    public static func fromBoolean(_ value: Bool) -> Dictionary<String, Bool> {
         return value ? successResponse() : failResponse()
     }
 
-    static func successResponse() -> [String: Bool] {
+    public static func successResponse() -> Dictionary<String, Bool> {
         return [VALUE_RESPONSE_KEY: true]
     }
 
-    static func failResponse() -> [String: Bool] {
+    public static func failResponse() -> Dictionary<String, Bool> {
         return [VALUE_RESPONSE_KEY: false]
     }
 
-    static func dataResponse(_ data: Any) -> [String: Any] {
+    public static func dataResponse(_ data: Any) -> Dictionary<String, Any> {
         return [VALUE_RESPONSE_KEY: data]
     }
 
-    static func statusResponse(_ data: CurrentRecordingStatus) -> [String: String] {
+    public static func statusResponse(_ data: CurrentRecordingStatus) -> Dictionary<String, String> {
         return [STATUS_RESPONSE_KEY: data.rawValue]
     }
 

--- a/ios/Plugin/VoiceRecorder.swift
+++ b/ios/Plugin/VoiceRecorder.swift
@@ -5,12 +5,12 @@ import Capacitor
 @objc(VoiceRecorder)
 public class VoiceRecorder: CAPPlugin {
 
-    private var customMediaRecorder: CustomMediaRecorder? = nil
-    
+    private var customMediaRecorder: CustomMediaRecorder?
+
     @objc func canDeviceVoiceRecord(_ call: CAPPluginCall) {
         call.resolve(ResponseGenerator.successResponse())
     }
-    
+
     @objc func requestAudioRecordingPermission(_ call: CAPPluginCall) {
         AVAudioSession.sharedInstance().requestRecordPermission { granted in
             if granted {
@@ -20,29 +20,28 @@ public class VoiceRecorder: CAPPlugin {
             }
         }
     }
-    
+
     @objc func hasAudioRecordingPermission(_ call: CAPPluginCall) {
         call.resolve(ResponseGenerator.fromBoolean(doesUserGaveAudioRecordingPermission()))
     }
-    
-    
+
     @objc func startRecording(_ call: CAPPluginCall) {
-        if(!doesUserGaveAudioRecordingPermission()) {
+        if !doesUserGaveAudioRecordingPermission() {
             call.reject(Messages.MISSING_PERMISSION)
             return
         }
-        
-        if(customMediaRecorder != nil) {
+
+        if customMediaRecorder != nil {
             call.reject(Messages.ALREADY_RECORDING)
             return
         }
-        
+
         customMediaRecorder = CustomMediaRecorder()
-        if(customMediaRecorder == nil) {
+        if customMediaRecorder == nil {
             call.reject(Messages.CANNOT_RECORD_ON_THIS_PHONE)
             return
         }
-        
+
         let successfullyStartedRecording = customMediaRecorder!.startRecording()
         if successfullyStartedRecording == false {
             customMediaRecorder = nil
@@ -51,17 +50,17 @@ public class VoiceRecorder: CAPPlugin {
             call.resolve(ResponseGenerator.successResponse())
         }
     }
-    
+
     @objc func stopRecording(_ call: CAPPluginCall) {
-        if(customMediaRecorder == nil) {
+        if customMediaRecorder == nil {
             call.reject(Messages.RECORDING_HAS_NOT_STARTED)
             return
         }
-        
+
         customMediaRecorder?.stopRecording()
-        
+
         let audioFileUrl = customMediaRecorder?.getOutputFile()
-        if(audioFileUrl == nil) {
+        if audioFileUrl == nil {
             customMediaRecorder = nil
             call.reject(Messages.FAILED_TO_FETCH_RECORDING)
             return
@@ -78,54 +77,54 @@ public class VoiceRecorder: CAPPlugin {
             call.resolve(ResponseGenerator.dataResponse(recordData.toDictionary()))
         }
     }
-    
+
     @objc func pauseRecording(_ call: CAPPluginCall) {
-        if(customMediaRecorder == nil) {
+        if customMediaRecorder == nil {
             call.reject(Messages.RECORDING_HAS_NOT_STARTED)
         } else {
             call.resolve(ResponseGenerator.fromBoolean(customMediaRecorder?.pauseRecording() ?? false))
         }
     }
-    
+
     @objc func resumeRecording(_ call: CAPPluginCall) {
-        if(customMediaRecorder == nil) {
+        if customMediaRecorder == nil {
             call.reject(Messages.RECORDING_HAS_NOT_STARTED)
         } else {
             call.resolve(ResponseGenerator.fromBoolean(customMediaRecorder?.resumeRecording() ?? false))
         }
     }
-    
+
     @objc func getCurrentStatus(_ call: CAPPluginCall) {
-        if(customMediaRecorder == nil) {
+        if customMediaRecorder == nil {
             call.resolve(ResponseGenerator.statusResponse(CurrentRecordingStatus.NONE))
         } else {
             call.resolve(ResponseGenerator.statusResponse(customMediaRecorder?.getCurrentStatus() ?? CurrentRecordingStatus.NONE))
         }
     }
-    
+
     func doesUserGaveAudioRecordingPermission() -> Bool {
         return AVAudioSession.sharedInstance().recordPermission == AVAudioSession.RecordPermission.granted
     }
-    
+
     func readFileAsBase64(_ filePath: URL?) -> String? {
-        if(filePath == nil) {
+        if filePath == nil {
             return nil
         }
-        
+
         do {
             let fileData = try Data.init(contentsOf: filePath!)
             let fileStream = fileData.base64EncodedString(options: NSData.Base64EncodingOptions.init(rawValue: 0))
             return fileStream
         } catch {}
-        
+
         return nil
     }
-    
+
     func getMsDurationOfAudioFile(_ filePath: URL?) -> Int {
         if filePath == nil {
             return -1
         }
         return Int(CMTimeGetSeconds(AVURLAsset(url: filePath!).duration) * 1000)
     }
-    
+
 }

--- a/ios/PluginTests/VoiceRecorderTests.swift
+++ b/ios/PluginTests/VoiceRecorderTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import Plugin
 
 class VoiceRecorderTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
 
     func testEcho() {
         // This is an example of a functional test case for a plugin.

--- a/ios/PluginTests/VoiceRecorderTests.swift
+++ b/ios/PluginTests/VoiceRecorderTests.swift
@@ -2,15 +2,6 @@ import XCTest
 @testable import Plugin
 
 class VoiceRecorderTests: XCTestCase {
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
 
     func testEcho() {
         // This is an example of a functional test case for a plugin.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "capacitor-voice-recorder",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-voice-recorder",
-      "version": "6.0.1",
+      "version": "6.0.3",
       "license": "MIT",
       "dependencies": {
+        "capacitor-blob-writer": "^1.1.19",
         "get-blob-duration": "^1.2.0"
       },
       "devDependencies": {
@@ -29,7 +30,8 @@
         "typescript": "<4.5.0"
       },
       "peerDependencies": {
-        "@capacitor/core": "^6.0.0"
+        "@capacitor/core": "^6.0.0",
+        "@capacitor/filesystem": "^6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -161,7 +163,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-6.1.2.tgz",
       "integrity": "sha512-xFy1/4qLFLp5WCIzIhtwUuVNNoz36+V7/BzHmLqgVJcvotc4MMjswW/TshnPQaLLujEOaLkA4h8ZJ0uoK3ImGg==",
-      "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -196,6 +197,16 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@capacitor/filesystem": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-6.0.3.tgz",
+      "integrity": "sha512-PdIP/yOGAbG1lq1wbFbSPhXQ9/5lpTpeiok2NneawJOk6UXvy9W7QZXRo7wXAP7J6FdzU7bKfOORRXpOJpgXyw==",
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@capacitor/core": "^6.0.0"
       }
     },
     "node_modules/@capacitor/ios": {
@@ -1092,6 +1103,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/capacitor-blob-writer": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/capacitor-blob-writer/-/capacitor-blob-writer-1.1.19.tgz",
+      "integrity": "sha512-2uZjL/y6F2yblA6lc5SP0JE+rQhxZcinmsLQKwGuSIDQySAdrcDkCAoQ07nqQV9qMtaeWsVTD6n08wo4R2sSjA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=3.0.0",
+        "@capacitor/filesystem": ">=1.0.0"
       }
     },
     "node_modules/chalk": {
@@ -3717,8 +3738,7 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "capacitor-blob-writer": "^1.1.19",
     "get-blob-duration": "^1.2.0"
   },
   "devDependencies": {
@@ -73,7 +74,8 @@
     "typescript": "<4.5.0"
   },
   "peerDependencies": {
-    "@capacitor/core": "^6.0.0"
+    "@capacitor/core": "^6.0.0",
+    "@capacitor/filesystem": "^6.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -180,7 +180,7 @@ export class VoiceRecorderImpl {
 
         let uri;
         let recordDataBase64;
-        if ('directory' in options) {
+        if (options != null) {
           const subDirectory = options.subDirectory?.match(/^\/?(.+[^/])\/?$/)?.[1] ?? '';
           const path = `${subDirectory}/recording-${new Date().getTime()}${POSSIBLE_MIME_TYPES[mimeType]}`;
 

--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -1,7 +1,15 @@
+import { Filesystem } from '@capacitor/filesystem';
+import write_blob from 'capacitor-blob-writer';
 import getBlobDuration from 'get-blob-duration';
 
 import { RecordingStatus } from './definitions';
-import type { Base64String, CurrentRecordingStatus, GenericResponse, RecordingData } from './definitions';
+import type {
+  Base64String,
+  CurrentRecordingStatus,
+  GenericResponse,
+  RecordingData,
+  RecordingOptions,
+} from './definitions';
 import {
   alreadyRecordingError,
   couldNotQueryPermissionStatusError,
@@ -16,7 +24,13 @@ import {
 } from './predefined-web-responses';
 
 // these mime types will be checked one by one in order until one of them is found to be supported by the current browser
-const possibleMimeTypes = ['audio/aac', 'audio/webm;codecs=opus', 'audio/mp4', 'audio/webm', 'audio/ogg;codecs=opus'];
+const POSSIBLE_MIME_TYPES = {
+  'audio/aac': '.aac',
+  'audio/webm;codecs=opus': '.ogg',
+  'audio/mp4': '.mp3',
+  'audio/webm': '.ogg',
+  'audio/ogg;codecs=opus': '.ogg',
+};
 const neverResolvingPromise = (): Promise<any> => new Promise(() => undefined);
 
 export class VoiceRecorderImpl {
@@ -32,7 +46,7 @@ export class VoiceRecorderImpl {
     }
   }
 
-  public async startRecording(): Promise<GenericResponse> {
+  public async startRecording(options: RecordingOptions): Promise<GenericResponse> {
     if (this.mediaRecorder != null) {
       throw alreadyRecordingError();
     }
@@ -47,7 +61,7 @@ export class VoiceRecorderImpl {
 
     return navigator.mediaDevices
       .getUserMedia({ audio: true })
-      .then(this.onSuccessfullyStartedRecording.bind(this))
+      .then((stream) => this.onSuccessfullyStartedRecording(stream, options))
       .catch(this.onFailedToStartRecording.bind(this));
   }
 
@@ -133,13 +147,17 @@ export class VoiceRecorderImpl {
     }
   }
 
-  public static getSupportedMimeType(): string | null {
+  public static getSupportedMimeType<T extends keyof typeof POSSIBLE_MIME_TYPES>(): T | null {
     if (MediaRecorder?.isTypeSupported == null) return null;
-    const foundSupportedType = possibleMimeTypes.find((type) => MediaRecorder.isTypeSupported(type));
+
+    const foundSupportedType = Object.keys(POSSIBLE_MIME_TYPES).find((type) => MediaRecorder.isTypeSupported(type)) as
+      | T
+      | undefined;
+
     return foundSupportedType ?? null;
   }
 
-  private onSuccessfullyStartedRecording(stream: MediaStream): GenericResponse {
+  private onSuccessfullyStartedRecording(stream: MediaStream, options: RecordingOptions): GenericResponse {
     this.pendingResult = new Promise((resolve, reject) => {
       this.mediaRecorder = new MediaRecorder(stream);
       this.mediaRecorder.onerror = () => {
@@ -159,10 +177,29 @@ export class VoiceRecorderImpl {
           reject(emptyRecordingError());
           return;
         }
-        const recordDataBase64 = await VoiceRecorderImpl.blobToBase64(blobVoiceRecording);
+
+        let uri;
+        let recordDataBase64;
+        if ('directory' in options) {
+          const subDirectory = options.subDirectory?.match(/^\/?(.+[^/])\/?$/)?.[1] ?? '';
+          const path = `${subDirectory}/recording-${new Date().getTime()}${POSSIBLE_MIME_TYPES[mimeType]}`;
+
+          await write_blob({
+            blob: blobVoiceRecording,
+            directory: options.directory,
+            fast_mode: true,
+            path,
+            recursive: true,
+          });
+
+          ({ uri } = await Filesystem.getUri({ directory: options.directory, path }));
+        } else {
+          recordDataBase64 = await VoiceRecorderImpl.blobToBase64(blobVoiceRecording);
+        }
+
         const recordingDuration = await getBlobDuration(blobVoiceRecording);
         this.prepareInstanceForNextOperation();
-        resolve({ value: { recordDataBase64, mimeType, msDuration: recordingDuration * 1000 } });
+        resolve({ value: { recordDataBase64, mimeType, msDuration: recordingDuration * 1000, uri } });
       };
       this.mediaRecorder.ondataavailable = (event: any) => this.chunks.push(event.data);
       this.mediaRecorder.start();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,12 +1,22 @@
+import type { Directory } from '@capacitor/filesystem';
+
 export type Base64String = string;
 
 export interface RecordingData {
   value: {
-    recordDataBase64: Base64String;
+    recordDataBase64?: Base64String;
     msDuration: number;
     mimeType: string;
+    uri?: string;
   };
 }
+
+export type RecordingOptions =
+  | never
+  | {
+      directory: Directory;
+      subDirectory?: string;
+    };
 
 export interface GenericResponse {
   value: boolean;
@@ -29,7 +39,7 @@ export interface VoiceRecorderPlugin {
 
   hasAudioRecordingPermission(): Promise<GenericResponse>;
 
-  startRecording(): Promise<GenericResponse>;
+  startRecording(options: RecordingOptions): Promise<GenericResponse>;
 
   stopRecording(): Promise<RecordingData>;
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,13 @@
 import { WebPlugin } from '@capacitor/core';
 
 import { VoiceRecorderImpl } from './VoiceRecorderImpl';
-import type { CurrentRecordingStatus, GenericResponse, RecordingData, VoiceRecorderPlugin } from './definitions';
+import type {
+  CurrentRecordingStatus,
+  GenericResponse,
+  RecordingData,
+  RecordingOptions,
+  VoiceRecorderPlugin,
+} from './definitions';
 
 export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
   private voiceRecorderInstance = new VoiceRecorderImpl();
@@ -18,8 +24,8 @@ export class VoiceRecorderWeb extends WebPlugin implements VoiceRecorderPlugin {
     return VoiceRecorderImpl.requestAudioRecordingPermission();
   }
 
-  public startRecording(): Promise<GenericResponse> {
-    return this.voiceRecorderInstance.startRecording();
+  public startRecording(options: RecordingOptions): Promise<GenericResponse> {
+    return this.voiceRecorderInstance.startRecording(options);
   }
 
   public stopRecording(): Promise<RecordingData> {


### PR DESCRIPTION
## Summary
The company I work with is working on a voice recording app to record meetings up to 3 hours long (About 200MB).
We quickly stumbled upon a problem with the current implementation of capacitor-voice-recorder because recordings of more than 36MB would crash the device because it converts the files into base64 strings before it the native code can send the data to the webview so we tried looking for a way to improve the performance of handling large files.

The first solution we tried was to chunk the File before converting each chunk into a Base64String then join each base64 chunk and that seemed to work at first. We were now able to record files of more than 36MB altough it took some time (About `15s` for 36MB and `25s` for 80MB).

The latency was an issue we were willing to live with but as we kept testing we ended up having crashed again with 150MB+ files so we had to think of another solution.

We had a look at how some other large file Capacitor plugins work, like capacitor/camera, and realised that the way they manage large files is that they don't send a base64 string of the file to the webview at all and instead save the file in the filesystem directly and send the uri to that file instead.

We were going to save the files anyway so instead of doing what we were currently doing (`File -> Base64String -> App -> File -> Fileystem`) we figured it'd be a lot simpler to do that too and store the file directly (`File -> Filesystem`). This method allows recording files of more than 150MB without any issue and a lot faster, from our test a 180MB file takes `0.2s` to stop the recording.

### Example
```ts
import { VoiceRecorder } from 'capacitor-voice-recorder';
import { Capacitor } from '@capacitor/core';
import { Directory, Filesystem } from '@capacitor/filesystem'

await VoiceRecorder.startRecording({ directory: Directory.Data })
const { value } = await VoiceRecorder.stopRecording()
console.log(value) //=> { mimeType: string, msDuration: number, recordDataBase64: null, uri: string }

/** To play the audio file */
let url: string

if (Capacitor.getPlatform() === 'web') {
  const { data } = await Filesystem.readFile({ path: value.uri })
  url = URL.createObjectURL(data as Blob)
} else {
  url = Capacitor.convertFileSrc(value.uri)
}

const audio = new Audio(url)
audio.addEventListener('ended', () => {
  URL.revokeObjectURL(url) // revoke the url in web to remove the file from the memory
})

audio.play()

/** To load the file */
const response = await fetch(url)
const file = await response.blob()
```