### PR TITLE
fix(filesystem): return relative path instead of uri

### DIFF
--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/CustomMediaRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/CustomMediaRecorder.java
@@ -45,6 +45,7 @@ public class CustomMediaRecorder {
                 Pattern pattern = Pattern.compile("^/?(.+[^/])/?$");
                 Matcher matcher = pattern.matcher(subDirectory);
                 if (matcher.matches()) {
+                    options.setSubDirectory(matcher.group(1));
                     outputDir = new File(outputDir, matcher.group(1));
                     if (!outputDir.exists()) {
                         outputDir.mkdirs();

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordData.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordData.java
@@ -4,18 +4,18 @@ import com.getcapacitor.JSObject;
 
 public class RecordData {
 
-    private String uri;
+    private String path;
     private String recordDataBase64;
     private String mimeType;
     private int msDuration;
 
     public RecordData() {}
 
-    public RecordData(String recordDataBase64, int msDuration, String mimeType, String uri) {
+    public RecordData(String recordDataBase64, int msDuration, String mimeType, String path) {
         this.recordDataBase64 = recordDataBase64;
         this.msDuration = msDuration;
         this.mimeType = mimeType;
-        this.uri = uri;
+        this.path = path;
     }
 
     public String getRecordDataBase64() {
@@ -47,7 +47,7 @@ public class RecordData {
         toReturn.put("recordDataBase64", recordDataBase64);
         toReturn.put("msDuration", msDuration);
         toReturn.put("mimeType", mimeType);
-        toReturn.put("uri", uri);
+        toReturn.put("path", path);
         return toReturn;
     }
 }

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordOptions.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/RecordOptions.java
@@ -17,4 +17,8 @@ public class RecordOptions {
     public String getSubDirectory() {
         return subDirectory;
     }
+
+    public void setSubDirectory(String subDirectory) {
+        this.subDirectory = subDirectory;
+    }
 }

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
@@ -102,10 +102,13 @@ public class VoiceRecorder extends Plugin {
             File recordedFile = mediaRecorder.getOutputFile();
             RecordOptions options = mediaRecorder.getRecordOptions();
 
+            String path = null;
             String recordDataBase64 = null;
-            String uri = null;
             if (options.getDirectory() != null) {
-                uri = Uri.fromFile(recordedFile).toString();
+                path = recordedFile.getName();
+                if (options.getSubDirectory() != null) {
+                  path = options.getSubDirectory() + "/" + path;
+                }
             } else {
                 recordDataBase64 = readRecordedFileAsBase64(recordedFile);
             }
@@ -114,9 +117,9 @@ public class VoiceRecorder extends Plugin {
                 recordDataBase64,
                 getMsDurationOfAudioFile(recordedFile.getAbsolutePath()),
                 "audio/aac",
-                uri
+                path
             );
-            if ((recordDataBase64 == null && uri == null) || recordData.getMsDuration() < 0) {
+            if ((recordDataBase64 == null && path == null) || recordData.getMsDuration() < 0) {
                 call.reject(Messages.EMPTY_RECORDING);
             } else {
                 call.resolve(ResponseGenerator.dataResponse(recordData.toJSObject()));

--- a/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
+++ b/android/src/main/java/com/tchvu3/capacitorvoicerecorder/VoiceRecorder.java
@@ -107,7 +107,7 @@ public class VoiceRecorder extends Plugin {
             if (options.getDirectory() != null) {
                 path = recordedFile.getName();
                 if (options.getSubDirectory() != null) {
-                  path = options.getSubDirectory() + "/" + path;
+                    path = options.getSubDirectory() + "/" + path;
                 }
             } else {
                 recordDataBase64 = readRecordedFileAsBase64(recordedFile);

--- a/ios/Plugin/CustomMediaRecorder.swift
+++ b/ios/Plugin/CustomMediaRecorder.swift
@@ -21,6 +21,7 @@ class CustomMediaRecorder {
         if let directory = getDirectory(directory: options.directory),
            var outputDirURL = FileManager.default.urls(for: directory, in: .userDomainMask).first {
             if let subDirectory = options.subDirectory?.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
+                options.setSubDirectory(subDirectory)
                 outputDirURL = outputDirURL.appendingPathComponent(subDirectory, isDirectory: true)
 
                 do {

--- a/ios/Plugin/CustomMediaRecorder.swift
+++ b/ios/Plugin/CustomMediaRecorder.swift
@@ -21,7 +21,7 @@ class CustomMediaRecorder {
         if let directory = getDirectory(directory: options.directory),
            var outputDirURL = FileManager.default.urls(for: directory, in: .userDomainMask).first {
             if let subDirectory = options.subDirectory?.trimmingCharacters(in: CharacterSet(charactersIn: "/")) {
-                options.setSubDirectory(subDirectory)
+                options.setSubDirectory(to: subDirectory)
                 outputDirURL = outputDirURL.appendingPathComponent(subDirectory, isDirectory: true)
 
                 do {

--- a/ios/Plugin/RecordData.swift
+++ b/ios/Plugin/RecordData.swift
@@ -5,14 +5,14 @@ struct RecordData {
     let recordDataBase64: String?
     let mimeType: String
     let msDuration: Int
-    let uri: String?
+    let path: String?
 
     func toDictionary() -> [String: Any] {
         return [
             "recordDataBase64": recordDataBase64 ?? "",
             "msDuration": msDuration,
             "mimeType": mimeType,
-            "uri": uri ?? ""
+            "path": path ?? ""
         ]
     }
 

--- a/ios/Plugin/RecordOptions.swift
+++ b/ios/Plugin/RecordOptions.swift
@@ -3,7 +3,7 @@ import Foundation
 struct RecordOptions {
 
     let directory: String?
-    let subDirectory: String?
+    var subDirectory: String?
 
     mutating func setSubDirectory(to subDirectory: String) {
       self.subDirectory = subDirectory

--- a/ios/Plugin/RecordOptions.swift
+++ b/ios/Plugin/RecordOptions.swift
@@ -5,4 +5,8 @@ struct RecordOptions {
     let directory: String?
     let subDirectory: String?
 
+    mutating func setSubDirectory(to subDirectory: String) {
+      self.subDirectory = subDirectory
+    }
+
 }

--- a/ios/Plugin/VoiceRecorder.swift
+++ b/ios/Plugin/VoiceRecorder.swift
@@ -69,12 +69,17 @@ public class VoiceRecorder: CAPPlugin {
             return
         }
 
+        let path = audioFileUrl!.lastPathComponent
+        if customMediaRecorder.options.subDirectory != nil {
+          path = customMediaRecorder.options.subDirectory + "/" + path
+        }
+
         let sendDataAsBase64 = customMediaRecorder?.options?.directory == nil
         let recordData = RecordData(
             recordDataBase64: sendDataAsBase64 ? readFileAsBase64(audioFileUrl) : nil,
             mimeType: "audio/aac",
             msDuration: getMsDurationOfAudioFile(audioFileUrl),
-            uri: sendDataAsBase64 ? nil : audioFileUrl!.path
+            path: sendDataAsBase64 ? nil : path
         )
         customMediaRecorder = nil
         if (sendDataAsBase64 && recordData.recordDataBase64 == nil) || recordData.msDuration < 0 {

--- a/ios/Plugin/VoiceRecorder.swift
+++ b/ios/Plugin/VoiceRecorder.swift
@@ -69,9 +69,9 @@ public class VoiceRecorder: CAPPlugin {
             return
         }
 
-        let path = audioFileUrl!.lastPathComponent
-        if customMediaRecorder.options.subDirectory != nil {
-          path = customMediaRecorder.options.subDirectory + "/" + path
+        var path = audioFileUrl!.lastPathComponent
+        if let subDirectory = customMediaRecorder?.options?.subDirectory {
+            path = subDirectory + "/" + path
         }
 
         let sendDataAsBase64 = customMediaRecorder?.options?.directory == nil

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-voice-recorder",
-  "version": "7.0.0",
+  "version": "7.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-voice-recorder",
-      "version": "7.0.0",
+      "version": "7.0.5",
       "license": "MIT",
       "dependencies": {
         "capacitor-blob-writer": "^1.1.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
         "typescript": "<4.5.0"
       },
       "peerDependencies": {
-        "@capacitor/core": ">=7.0.0",
-        "@capacitor/filesystem": "^7.0.0"
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "typescript": "<4.5.0"
   },
   "peerDependencies": {
-    "@capacitor/core": ">=7.0.0",
-    "@capacitor/filesystem": "^7.0.0"
+    "@capacitor/core": ">=7.0.0"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",

--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -1,4 +1,3 @@
-import { Filesystem } from '@capacitor/filesystem';
 import write_blob from 'capacitor-blob-writer';
 import getBlobDuration from 'get-blob-duration';
 
@@ -178,11 +177,11 @@ export class VoiceRecorderImpl {
           return;
         }
 
-        let uri;
+        let path;
         let recordDataBase64;
         if (options != null) {
           const subDirectory = options.subDirectory?.match(/^\/?(.+[^/])\/?$/)?.[1] ?? '';
-          const path = `${subDirectory}/recording-${new Date().getTime()}${POSSIBLE_MIME_TYPES[mimeType]}`;
+          path = `${subDirectory}/recording-${new Date().getTime()}${POSSIBLE_MIME_TYPES[mimeType]}`;
 
           await write_blob({
             blob: blobVoiceRecording,
@@ -191,15 +190,13 @@ export class VoiceRecorderImpl {
             path,
             recursive: true,
           });
-
-          ({ uri } = await Filesystem.getUri({ directory: options.directory, path }));
         } else {
           recordDataBase64 = await VoiceRecorderImpl.blobToBase64(blobVoiceRecording);
         }
 
         const recordingDuration = await getBlobDuration(blobVoiceRecording);
         this.prepareInstanceForNextOperation();
-        resolve({ value: { recordDataBase64, mimeType, msDuration: recordingDuration * 1000, uri } });
+        resolve({ value: { recordDataBase64, mimeType, msDuration: recordingDuration * 1000, path } });
       };
       this.mediaRecorder.ondataavailable = (event: any) => this.chunks.push(event.data);
       this.mediaRecorder.start();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,7 +7,7 @@ export interface RecordingData {
     recordDataBase64?: Base64String;
     msDuration: number;
     mimeType: string;
-    uri?: string;
+    path?: string;
   };
 }
 


### PR DESCRIPTION
closes https://github.com/tchvu3/capacitor-voice-recorder/issues/111

## Summary
On iOS devices a file URI includes the application sandbox's UUID.
For example `"/var/mobile/Applications/7AC2295E-2775-41EA-B017-AB4048A09F0C/Document/recording-123.aac"`

The problem is that this UUID changes after some period of time so if that URI was saved in a metadata file to grab the audio file for later use this URI might ne direct to an existing file anymore.

In order to fix this we changed the response of `VoiceRecorder.stopRecording` to return the absolute path of the audio file instead of the full URI.
A URI can then be generated from the path and the filesystem Directory like so
```js
import { Directory, Filesystem } from '@capacitor/filesystem'
import { VoiceRecorder } from 'capacitor-voice-recorder'

await VoiceRecorder.startRecording({ directory: Directory.Data })
const { value } = await VoiceRecorder.stopRecording();
const { uri } = await Filesystem.getUri({ directory: Directory.Data, path: value.path });
```

**⚠️ BREAKING CHANGE**
The `VoiceRecorder.stopRecording` method does not return a `uri` anymore but a `path`.