### PR TITLE
fix: change order of possible mime types to prefer audio/mp4 over aud…

### DIFF
--- a/src/VoiceRecorderImpl.ts
+++ b/src/VoiceRecorderImpl.ts
@@ -26,8 +26,8 @@ import {
 // these mime types will be checked one by one in order until one of them is found to be supported by the current browser
 const POSSIBLE_MIME_TYPES = {
   'audio/aac': '.aac',
-  'audio/webm;codecs=opus': '.ogg',
   'audio/mp4': '.mp3',
+  'audio/webm;codecs=opus': '.ogg',
   'audio/webm': '.ogg',
   'audio/ogg;codecs=opus': '.ogg',
 };


### PR DESCRIPTION
Safari claims to support webm since version 18.4 on iOS and macOS (see [release notes](https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes#Media)). Therefore `MediaRecorder.isTypeSupported('audio/webm;codecs=opus')` returns true.

But while the recording itself seems to work, calculating the duration (using `get-blob-duration` lib) and also the playback using the base64 string fails.

<img width="838" alt="safari-media-error" src="https://github.com/user-attachments/assets/dc0793d6-9b21-4f33-a26b-1c791c2ee241" />

Changing the order of the possible mime types to prefer audio/mp4 over audio/webm fixes that issue.

